### PR TITLE
hello_world_main : fix incorrect printf format

### DIFF
--- a/examples/get-started/hello_world/main/hello_world_main.c
+++ b/examples/get-started/hello_world/main/hello_world_main.c
@@ -28,7 +28,7 @@ void app_main(void)
 
     printf("silicon revision %d, ", chip_info.revision);
 
-    printf("%dMB %s flash\n", spi_flash_get_chip_size() / (1024 * 1024),
+    printf("%zuMB %s flash\n", spi_flash_get_chip_size() / (1024 * 1024),
             (chip_info.features & CHIP_FEATURE_EMB_FLASH) ? "embedded" : "external");
 
     printf("Minimum free heap size: %d bytes\n", esp_get_minimum_free_heap_size());


### PR DESCRIPTION
spi_flash_get_chip_size return a size_t to printf this type it's better to use %zu than %d.
This commit change that.